### PR TITLE
Unfreeze dependencies versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        'dacite==1.1.0',
-        'requests==2.22.0',
+        'dacite>=1.1.0',
+        'requests>=2.20.0',
     ],
     extras_require={
         'tests': [

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,8 @@ setup(
     ],
     python_requires='>=3.7',
     install_requires=[
-        'dacite>=1.1.0',
-        'requests>=2.20.0',
+        'dacite>=1.1.0,<2',
+        'requests>=2.20.0,<3',
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
As this is a client package, designed to be used in different packages, I believe it is reasonable not to freeze package versions, but require a minimal supported version.