### PR TITLE
deprecate availability_ids parameter in get_calendar method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.3
+
+- Update the `get_calendar` method to remove the parameter `availability_ids`.
+
 ## 1.1.2
 
 - Update the client to add a function to build the endpoint's URL for requests to a given supplier.

--- a/octo_client/client.py
+++ b/octo_client/client.py
@@ -259,9 +259,23 @@ class OctoClient(object):
         option_id: str,
         local_date_start: date,
         local_date_end: date,
-        availability_ids: Optional[List[str]] = None,
         units: Optional[List[models.UnitQuantity]] = None,
     ) -> List[models.AvailabilityCalendarItem]:
+        """This method retrieve the availability calendar for a range of dates.
+
+        Args:
+            supplier_id: retrieve calendar data for the supplier with this ID.
+            product_id: retrieve calendar data for a product with this ID.
+            option_id: retrieve calendar data for the option with this ID.
+            local_date_start: retrieve calendar data from this date onwards.
+            local_date_end: retrieve calendar data until this date.
+            units: a list of units. Each unit requires:
+                - id
+                - quantity
+
+        Returns: a list of availability objects; one object per each day in the range of dates.
+        """
+
         payload: Dict[str, Any] = {
             "productId": product_id,
             "optionId": option_id,
@@ -270,8 +284,6 @@ class OctoClient(object):
             payload["localDateStart"] = local_date_start.isoformat()
         if local_date_end:
             payload["localDateEnd"] = local_date_end.isoformat()
-        if availability_ids:
-            payload["availabilityIds"] = availability_ids
         if units:
             payload["units"] = [unit.as_dict() for unit in units]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octo-api-client"
-version = "1.1.2"
+version = "1.1.3"
 description = "HTTP client for OCTo (Open Connection for Tourism) APIs."
 authors = ["Tiqets <connections@tiqets.com>"]
 license = "MIT"


### PR DESCRIPTION
Update the `get_calendar` method to remove the parameter `availability_ids`.