### PR TITLE
[Hide Users sensible Data] Handle lists data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.7
+
+- Handle list data when hidding client sensitive data
+
 ## 1.1.6
 
 - Fix client displaying sensitive data in logs

--- a/octo_client/client.py
+++ b/octo_client/client.py
@@ -127,7 +127,7 @@ class OctoClient(object):
         )
         self._raise_for_status(response.status_code, response.text)
         try:
-            response_json = response.json()
+            response_json: dict = response.json()
         except Exception as exc:
             self.logger.log(
                 self.requests_loglevel,
@@ -145,8 +145,8 @@ class OctoClient(object):
         return response_json
 
     def _filter_request_log_data(
-        self, request_content: Union[str, dict]
-    ) -> Optional[Union[str, dict]]:
+        self, request_content: Union[str, dict, list]
+    ) -> Optional[Union[str, dict, list]]:
         if self.log_requests:
             content = hide_sensitive_data(copy.deepcopy(request_content))
             if self.log_size_limit and len(content) > self.log_size_limit:
@@ -155,8 +155,8 @@ class OctoClient(object):
         return None
 
     def _filter_response_log_data(
-        self, response_content: Union[str, dict]
-    ) -> Optional[Union[str, dict]]:
+        self, response_content: Union[str, dict, list]
+    ) -> Optional[Union[str, dict, list]]:
         if self.log_responses:
             content = hide_sensitive_data(copy.deepcopy(response_content))
             if self.log_size_limit and len(content) > self.log_size_limit:

--- a/octo_client/utils.py
+++ b/octo_client/utils.py
@@ -4,8 +4,8 @@ from octo_client.const import PRIVATE_DATA_KEYS, PRIVATE_DATA_REPLACEMENT
 
 
 def hide_sensitive_data(
-    data: Union[str, dict], keys: List[str] = PRIVATE_DATA_KEYS
-) -> Union[str, dict]:
+    data: Union[str, list, dict], keys: List[str] = PRIVATE_DATA_KEYS
+) -> Union[str, list, dict]:
     """
     Hide sensitive data from a nested dict by doing a partial match on the keys.
     data: dict to be filtered
@@ -14,11 +14,14 @@ def hide_sensitive_data(
     if isinstance(data, str):
         return data
 
-    for k, v in data.items():
-        if isinstance(v, dict):
+    if isinstance(data, list):
+        return [hide_sensitive_data(item, keys) for item in data]
+
+    if isinstance(data, dict):
+        for k, v in data.items():
             hide_sensitive_data(v, keys)
 
-        for key in keys:
-            if key in k.lower():
-                data[k] = PRIVATE_DATA_REPLACEMENT
+            for key in keys:
+                if key in k.lower():
+                    data[k] = PRIVATE_DATA_REPLACEMENT
     return data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "octo-api-client"
-version = "1.1.6"
+version = "1.1.7"
 description = "HTTP client for OCTo (Open Connection for Tourism) APIs."
 authors = ["Tiqets <connections@tiqets.com>"]
 license = "MIT"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,40 +2,72 @@ from octo_client.utils import hide_sensitive_data
 
 
 def test_hide_sensitive_data():
-    data = {
-        "nonSensitiveData": "foo",
-        "otherNonSensitiveData": {
-            "isItSensitive": "I don't think so ;)",
-        },
-        "userAddress": "1234 Main St",
-        "userCity": "Anytown",
-        "userZip": "12345",
-        "userCountry": "USA",
-        "userState": "CA",
-        "contact": {
-            "firstName": "John",
-            "lastName": "Doe",
-            "userEmail": "foo@boo.com",
-            "userPhone": "1234567890",
-        },
-    }
+    data = [
+        {
+            "nonSensitiveData": "foo",
+            "otherNonSensitiveData": {
+                "isItSensitive": "I don't think so ;)",
+            },
+            "userAddress": "1234 Main St",
+            "userCity": "Anytown",
+            "userZip": "12345",
+            "userCountry": "USA",
+            "userState": "CA",
+            "contact": {
+                "firstName": "John",
+                "lastName": "Doe",
+                "userEmail": "foo@boo.com",
+                "userPhone": "1234567890",
+            },
+            "listOfSensitiveData": [
+                {
+                    "userPhone": "1234567890",
+                    "userAddtionalData": {
+                        "userSecondPhone": "1234567890",
+                    },
+                },
+                {
+                    "userPhone": "1234567890",
+                },
+                {
+                    "userPhone": "1234567890",
+                },
+            ],
+        }
+    ]
 
     result = hide_sensitive_data(data)
 
-    assert result == {
-        "nonSensitiveData": "foo",
-        "otherNonSensitiveData": {
-            "isItSensitive": "I don't think so ;)",
-        },
-        "userAddress": "[Filtered private data]",
-        "userCity": "[Filtered private data]",
-        "userZip": "[Filtered private data]",
-        "userCountry": "[Filtered private data]",
-        "userState": "[Filtered private data]",
-        "contact": {
-            "firstName": "[Filtered private data]",
-            "lastName": "[Filtered private data]",
-            "userEmail": "[Filtered private data]",
-            "userPhone": "[Filtered private data]",
-        },
-    }
+    assert result == [
+        {
+            "nonSensitiveData": "foo",
+            "otherNonSensitiveData": {
+                "isItSensitive": "I don't think so ;)",
+            },
+            "userAddress": "[Filtered private data]",
+            "userCity": "[Filtered private data]",
+            "userZip": "[Filtered private data]",
+            "userCountry": "[Filtered private data]",
+            "userState": "[Filtered private data]",
+            "contact": {
+                "firstName": "[Filtered private data]",
+                "lastName": "[Filtered private data]",
+                "userEmail": "[Filtered private data]",
+                "userPhone": "[Filtered private data]",
+            },
+            "listOfSensitiveData": [
+                {
+                    "userPhone": "[Filtered private data]",
+                    "userAddtionalData": {
+                        "userSecondPhone": "[Filtered private data]",
+                    },
+                },
+                {
+                    "userPhone": "[Filtered private data]",
+                },
+                {
+                    "userPhone": "[Filtered private data]",
+                },
+            ],
+        }
+    ]


### PR DESCRIPTION
# Why
Turns out we had some use cases where the data returned from the Octor-API is a list and not always a dict. This issue was detected when upgrading the Octo-Client version number and some tests have failed.

# How
Update the `hide_sensitive_data` to handle list data type.